### PR TITLE
Added copy_relations function in models.py

### DIFF
--- a/cmsplugin_filery/models.py
+++ b/cmsplugin_filery/models.py
@@ -32,6 +32,13 @@ class Filery(CMSPlugin):
         return self.image_set.filter(active=True)
 
 
+    def copy_relations(self, oldinstance):
+        for img in oldinstance.image_set.all():
+            new_img = Image()
+    	    new_img.gallery = self
+    	    new_img.image = img.image
+            new_img.save()
+
     class Meta:
         verbose_name = _('filery')
         verbose_name_plural = _('fileries')
@@ -104,3 +111,4 @@ class Image(models.Model):
         verbose_name = _('image')
         verbose_name_plural = _('images')
         ordering = ('order',)
+


### PR DESCRIPTION
copy_relations function is needed for django_cms 2.4, to ensure that images are copied from draft to published pages.
